### PR TITLE
Add options to allow extending expiring URL generation

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -186,9 +186,9 @@ module Paperclip
         end unless Paperclip::Interpolations.respond_to? :asset_host
       end
 
-      def expiring_url(time = 3600, style_name = default_style)
+      def expiring_url(time = 3600, style_name = default_style, extra_options = {})
         if path(style_name)
-          base_options = { expires_in: time }
+          base_options = { expires_in: time }.merge(extra_options)
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options),


### PR DESCRIPTION
### Description

We need the ability to be able to set `response_content_disposition: "attachment"` to resolve an XSS issue with SVG files.