### PR TITLE
Updates to support Ruby 3

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,7 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      super(URI(URI.escape(target)), options)
+      super(URI(URI::DEFAULT_PARSER.escape(target)), options)
     end
   end
 end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -64,7 +64,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        URI::DEFAULT_PARSER.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -40,7 +40,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, types)
-        record.errors.add attribute, :invalid, options.merge(:types => types.join(', '))
+        record.errors.add attribute, :invalid, **options.merge(:types => types.join(', '))
       end
 
       def allowed_types

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -40,7 +40,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, patterns)
-        record.errors.add attribute, :invalid, options.merge(:names => patterns.join(', '))
+        record.errors.add attribute, :invalid, **options.merge(:names => patterns.join(', '))
       end
 
       def allowed

--- a/lib/paperclip/validators/attachment_presence_validator.rb
+++ b/lib/paperclip/validators/attachment_presence_validator.rb
@@ -5,7 +5,7 @@ module Paperclip
     class AttachmentPresenceValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, value)
         if record.send("#{attribute}_file_name").blank?
-          record.errors.add(attribute, :blank, options)
+          record.errors.add(attribute, :blank, **options)
         end
       end
 

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -27,7 +27,7 @@ module Paperclip
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
               [ attr_name, base_attr_name ].each do |error_attr_name|
-                record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
+                record.errors.add(error_attr_name, error_message_key, **filtered_options(value).merge(
                   :min => min_value_in_human_size(record),
                   :max => max_value_in_human_size(record),
                   :count => human_size(option_value)


### PR DESCRIPTION
These are the minimum required updates for the gem to support Ruby 3. Most of the changes are related to https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

#### Why not use upstream?

Paperclip is no longer under development since ActiveStorage was released and our copy of the gem needs to be brought into sync with upstream.  Rather than spending the time to get an no longer supported upstream gem working, I think we should look at using that time to migrate away from paperclip to a supported alternative.
