### PR TITLE
rebuild CHECKS in validator for rails 7 upgrade

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -5,6 +5,10 @@ module Paperclip
     class AttachmentSizeValidator < ActiveModel::Validations::NumericalityValidator
       AVAILABLE_CHECKS = [:less_than, :less_than_or_equal_to, :greater_than, :greater_than_or_equal_to]
 
+      if ActiveRecord::VERSION::MAJOR >= 7
+        CHECKS = COMPARE_CHECKS.merge(NUMBER_CHECKS)
+      end
+
       def initialize(options)
         extract_options(options)
         super


### PR DESCRIPTION
Related to BEI-320

Paperclip adds some validators which inherit from `ActiveModel::Validations::NumericalityValidator`. In rails 6 they had a constant [CHECKS](https://github.com/rails/rails/blob/v6.1.7.9/activemodel/lib/active_model/validations/numericality.rb#L8), but in rails 7 + these have been split out into multiple constants [RANGE_CHECKS, NUMBER_CHECKS, etc](https://github.com/rails/rails/blob/v7.1.4/activemodel/lib/active_model/validations/numericality.rb#L13-L14)

[Paperclip is archived](https://linear.app/clio/issue/BEI-320/update-or-remove-paperclip-gem) and we use a fork of an even older version. Switching to ActiveStorage is the long term solution but way out of scope of the rails 7 upgrade. Instead, we'll just rebuild the CHECKS constant if we're in rails 7.