### PR TITLE
Fixnum - Ruby 3.3+ Compatibility

### DIFF
--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -184,7 +184,7 @@ module Paperclip
       private
 
       def convert_time(time)
-        if time.is_a?(Fixnum)
+        if time.is_a?(Integer)
           time = Time.now + time
         end
         time

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   unless defined?(Paperclip::VERSION)
-    VERSION = "5.2.2".freeze
+    VERSION = "5.3.0".freeze
   end
 end

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,5 +1,5 @@
 module Paperclip
   unless defined?(Paperclip::VERSION)
-    VERSION = "5.3.0".freeze
+    VERSION = "5.2.2".freeze
   end
 end


### PR DESCRIPTION
Change Fixnum to Integer for Ruby 3.3+ compatibility. 

In Ruby 3.3.8 Grow update, if we hit this method, the following error will occur:
`NameError: uninitialized constant Fixnum`